### PR TITLE
API key authentication

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -27,4 +27,3 @@ packages:
       dir: "{{.InterfaceDir}}"
     interfaces:
       Dispatcher:
-# testonly: True

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.22 as builder
+FROM --platform=$BUILDPLATFORM golang:1.22 AS builder
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ GLOBAL OPTIONS:
    --log-level value   set the log level. Options: debug, info, warn, error, panic, fatal. [$LOG_LEVEL]
    --version           print the version
 
+   auth
+
+   --auth-key value, -k value  the authentication key to use for incoming requests. [$AUTH_KEY]
+
    function
 
    --arg value, -a value [ --arg value, -a value ]  additional arguments for to the worker process. [$FUNCTION_ARGS]

--- a/app/app.go
+++ b/app/app.go
@@ -1,13 +1,14 @@
 package app
 
 import (
+	"github.com/urfave/cli/v2"
+	"go.uber.org/fx"
+
 	"github.com/lambda-feedback/shimmy/config"
 	"github.com/lambda-feedback/shimmy/internal/shell"
 	"github.com/lambda-feedback/shimmy/runtime"
 	"github.com/lambda-feedback/shimmy/util/conf"
 	"github.com/lambda-feedback/shimmy/util/logging"
-	"github.com/urfave/cli/v2"
-	"go.uber.org/fx"
 )
 
 func New(ctx *cli.Context) (*shell.Shell, error) {

--- a/app/lambda/handler.go
+++ b/app/lambda/handler.go
@@ -7,9 +7,10 @@ import (
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/awslabs/aws-lambda-go-api-proxy/httpadapter"
-	"github.com/lambda-feedback/shimmy/internal/server"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/internal/server"
 )
 
 // LambdaHandlerParams represents the parameters required for

--- a/app/lambda/module.go
+++ b/app/lambda/module.go
@@ -1,9 +1,10 @@
 package lambda
 
 import (
+	"go.uber.org/fx"
+
 	"github.com/lambda-feedback/shimmy/handler"
 	"github.com/lambda-feedback/shimmy/util/logging"
-	"go.uber.org/fx"
 )
 
 func Module(config Config) fx.Option {

--- a/app/standalone/module.go
+++ b/app/standalone/module.go
@@ -1,10 +1,11 @@
 package standalone
 
 import (
+	"go.uber.org/fx"
+
 	"github.com/lambda-feedback/shimmy/handler"
 	"github.com/lambda-feedback/shimmy/internal/server"
 	"github.com/lambda-feedback/shimmy/util/logging"
-	"go.uber.org/fx"
 )
 
 func Module(config Config) fx.Option {

--- a/cmd/lambda.go
+++ b/cmd/lambda.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"github.com/urfave/cli/v2"
+
 	"github.com/lambda-feedback/shimmy/app"
 	"github.com/lambda-feedback/shimmy/app/lambda"
 	"github.com/lambda-feedback/shimmy/util/conf"
 	"github.com/lambda-feedback/shimmy/util/logging"
-	"github.com/urfave/cli/v2"
 )
 
 var (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"time"
 
+	"github.com/urfave/cli/v2"
+	"go.uber.org/zap"
+
 	"github.com/lambda-feedback/shimmy/config"
 	"github.com/lambda-feedback/shimmy/util/conf"
 	"github.com/lambda-feedback/shimmy/util/logging"
-	"github.com/urfave/cli/v2"
-	"go.uber.org/zap"
 )
 
 var (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,13 @@ functions on arbitrary, serverless platforms.`
 				Usage:   "set the log format. Options: production, development.",
 				EnvVars: []string{"LOG_FORMAT"},
 			},
+			// auth flags
+			&cli.StringFlag{
+				Name:     "auth-key",
+				Usage:    "the secret key for the application.",
+				Category: "auth",
+				EnvVars:  []string{"AUTH_KEY"},
+			},
 			// shim flags
 			&cli.StringFlag{
 				Name:     "interface",
@@ -242,6 +249,7 @@ func parseRootConfig(ctx *cli.Context) (config.Config, error) {
 
 	// map cli flags to config fields
 	cliMap := map[string]string{
+		"auth-key":                   "auth.key",
 		"max-workers":                "runtime.max_workers",
 		"command":                    "runtime.cmd",
 		"cwd":                        "runtime.cwd",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,8 +3,9 @@ package cmd
 import (
 	"os"
 
-	"github.com/lambda-feedback/shimmy/util/logging"
 	"github.com/urfave/cli/v2"
+
+	"github.com/lambda-feedback/shimmy/util/logging"
 )
 
 var (

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,11 +1,12 @@
 package cmd
 
 import (
+	"github.com/urfave/cli/v2"
+
 	"github.com/lambda-feedback/shimmy/app"
 	"github.com/lambda-feedback/shimmy/app/standalone"
 	"github.com/lambda-feedback/shimmy/util/conf"
 	"github.com/lambda-feedback/shimmy/util/logging"
-	"github.com/urfave/cli/v2"
 )
 
 var (

--- a/config/config.go
+++ b/config/config.go
@@ -8,6 +8,11 @@ const (
 	JSON MessageEncoding = "json"
 )
 
+type AuthConfig struct {
+	// Key is the secret key for the application
+	Key string `conf:"key"`
+}
+
 type Config struct {
 	// LogLevel is the log level for the application
 	LogLevel string `conf:"log_level"`
@@ -17,4 +22,7 @@ type Config struct {
 
 	// Runtime is the runtime configuration
 	Runtime runtime.Config `conf:"runtime"`
+
+	// Auth is the authentication configuration
+	Auth AuthConfig `conf:"auth"`
 }

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"github.com/lambda-feedback/shimmy/config"
+	"github.com/lambda-feedback/shimmy/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// --- Mock handler ---
+type MockHandler struct {
+	mock.Mock
+}
+
+func (m *MockHandler) Handle(ctx context.Context, req runtime.Request) runtime.Response {
+	args := m.Called(ctx, req)
+	return args.Get(0).(runtime.Response)
+}
+
+// --- Test ---
+func TestServeHTTP_Success(t *testing.T) {
+	mockHandler := new(MockHandler)
+
+	reqBody := []byte(`{"example": "value"}`)
+	req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(reqBody))
+	req.Header.Set("api-key", "secret")
+
+	w := httptest.NewRecorder()
+
+	expectedResponse := runtime.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       []byte(`{"ok":true}`),
+	}
+
+	mockHandler.On("Handle", mock.Anything, mock.MatchedBy(func(r runtime.Request) bool {
+		return r.Path == "/test" &&
+			r.Method == http.MethodPost &&
+			bytes.Equal(r.Body, reqBody)
+	})).Return(expectedResponse)
+
+	handler := &CommandHandler{
+		handler: mockHandler,
+		log:     zap.NewNop(), // or zaptest.NewLogger(t)
+		config: config.Config{
+			LogLevel: "debug",
+			Runtime:  runtime.Config{},
+			Auth:     config.AuthConfig{Key: "secret"},
+		},
+	}
+
+	handler.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	body, _ := io.ReadAll(res.Body)
+
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, "application/json", res.Header.Get("Content-Type"))
+	assert.Equal(t, `{"ok":true}`, string(body))
+	mockHandler.AssertExpectations(t)
+}
+
+func TestServeHTTP_Unauthorized(t *testing.T) {
+	mockHandler := new(MockHandler)
+
+	req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader([]byte(`{"example": "value"}`)))
+	req.Header.Set("api-key", "wrong-key") // wrong key
+
+	w := httptest.NewRecorder()
+
+	handler := &CommandHandler{
+		handler: mockHandler, // won't be called
+		log:     zap.NewNop(),
+		config: config.Config{
+			LogLevel: "debug",
+			Runtime:  runtime.Config{},
+			Auth:     config.AuthConfig{Key: "Secret"},
+		},
+	}
+
+	handler.ServeHTTP(w, req)
+
+	res := w.Result()
+	defer res.Body.Close()
+
+	body, _ := io.ReadAll(res.Body)
+
+	assert.Equal(t, http.StatusUnauthorized, res.StatusCode)
+	assert.Contains(t, string(body), "unauthorized")
+
+	// Ensure handler was not called
+	mockHandler.AssertNotCalled(t, "Handle", mock.Anything, mock.Anything)
+}

--- a/internal/execution/dispatcher.go
+++ b/internal/execution/dispatcher.go
@@ -3,9 +3,10 @@ package execution
 import (
 	"context"
 
+	"go.uber.org/zap"
+
 	"github.com/lambda-feedback/shimmy/internal/execution/dispatcher"
 	"github.com/lambda-feedback/shimmy/internal/execution/supervisor"
-	"go.uber.org/zap"
 )
 
 type Dispatcher dispatcher.Dispatcher

--- a/internal/execution/dispatcher/dispatcher_dedicated.go
+++ b/internal/execution/dispatcher/dispatcher_dedicated.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/lambda-feedback/shimmy/internal/execution/supervisor"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/internal/execution/supervisor"
 )
 
 type DedicatedDispatcher struct {

--- a/internal/execution/dispatcher/dispatcher_pooled.go
+++ b/internal/execution/dispatcher/dispatcher_pooled.go
@@ -6,8 +6,9 @@ import (
 	"runtime"
 
 	"github.com/jackc/puddle/v2"
-	"github.com/lambda-feedback/shimmy/internal/execution/supervisor"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/internal/execution/supervisor"
 )
 
 type PooledDispatcher struct {

--- a/internal/execution/dispatcher/dispatcher_pooled_test.go
+++ b/internal/execution/dispatcher/dispatcher_pooled_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lambda-feedback/shimmy/internal/execution/dispatcher"
-	"github.com/lambda-feedback/shimmy/internal/execution/supervisor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/internal/execution/dispatcher"
+	"github.com/lambda-feedback/shimmy/internal/execution/supervisor"
 )
 
 func TestPooledDispatcher_New_UsesCPUCoreFallback(t *testing.T) {

--- a/internal/execution/supervisor/adapter.go
+++ b/internal/execution/supervisor/adapter.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/lambda-feedback/shimmy/internal/execution/worker"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/internal/execution/worker"
 )
 
 // AdapterWorkerFactoryFn is a type alias for a function that creates a worker

--- a/internal/execution/supervisor/adapter_file.go
+++ b/internal/execution/supervisor/adapter_file.go
@@ -12,8 +12,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/lambda-feedback/shimmy/internal/execution/worker"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/internal/execution/worker"
 )
 
 // fileAdapter is an adapter that allows supervisors to use files to

--- a/internal/execution/supervisor/adapter_file_test.go
+++ b/internal/execution/supervisor/adapter_file_test.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lambda-feedback/shimmy/internal/execution/worker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/internal/execution/worker"
 )
 
 func TestFileAdapter_Start_DoesNotStartWorker(t *testing.T) {

--- a/internal/execution/supervisor/adapter_rpc.go
+++ b/internal/execution/supervisor/adapter_rpc.go
@@ -11,8 +11,9 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/rpc"
-	"github.com/lambda-feedback/shimmy/internal/execution/worker"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/internal/execution/worker"
 )
 
 // RpcConfig describes the configuration for the rpc interface.

--- a/internal/execution/supervisor/adapter_rpc_test.go
+++ b/internal/execution/supervisor/adapter_rpc_test.go
@@ -6,10 +6,11 @@ import (
 	"io"
 	"testing"
 
-	"github.com/lambda-feedback/shimmy/internal/execution/worker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/internal/execution/worker"
 )
 
 type rwc struct {

--- a/internal/execution/supervisor/adapter_test.go
+++ b/internal/execution/supervisor/adapter_test.go
@@ -3,9 +3,10 @@ package supervisor
 import (
 	"testing"
 
-	"github.com/lambda-feedback/shimmy/internal/execution/worker"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/internal/execution/worker"
 )
 
 func TestDefaultAdapterFactory(t *testing.T) {

--- a/internal/execution/supervisor/supervisor.go
+++ b/internal/execution/supervisor/supervisor.go
@@ -6,8 +6,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/lambda-feedback/shimmy/internal/execution/worker"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/internal/execution/worker"
 )
 
 type Supervisor interface {

--- a/internal/execution/supervisor/supervisor_test.go
+++ b/internal/execution/supervisor/supervisor_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/lambda-feedback/shimmy/internal/execution/supervisor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/internal/execution/supervisor"
 )
 
 func TestSupervisor_New_DefaultWorkerFactory(t *testing.T) {

--- a/internal/execution/worker/worker_test.go
+++ b/internal/execution/worker/worker_test.go
@@ -9,10 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/lambda-feedback/shimmy/internal/execution/worker"
-	"github.com/lambda-feedback/shimmy/util"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/internal/execution/worker"
+	"github.com/lambda-feedback/shimmy/util"
 )
 
 func TestWorker_Start_IsAlive(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/getsentry/sentry-go"
+
 	"github.com/lambda-feedback/shimmy/cmd"
 	"github.com/lambda-feedback/shimmy/util"
 )

--- a/runtime/handler.go
+++ b/runtime/handler.go
@@ -7,9 +7,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/lambda-feedback/shimmy/runtime/schema"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/runtime/schema"
 )
 
 var (

--- a/runtime/handler_validate.go
+++ b/runtime/handler_validate.go
@@ -3,9 +3,10 @@ package runtime
 import (
 	"fmt"
 
-	"github.com/lambda-feedback/shimmy/runtime/schema"
 	"github.com/xeipuuv/gojsonschema"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/runtime/schema"
 )
 
 // validationType is the type of validation.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -3,9 +3,10 @@ package runtime
 import (
 	"context"
 
-	"github.com/lambda-feedback/shimmy/internal/execution"
 	"go.uber.org/fx"
 	"go.uber.org/zap"
+
+	"github.com/lambda-feedback/shimmy/internal/execution"
 )
 
 // Runtime is the interface for a runtime.

--- a/util/conf/parse.go
+++ b/util/conf/parse.go
@@ -9,8 +9,9 @@ import (
 	"github.com/knadh/koanf/providers/env"
 	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/v2"
-	"github.com/lambda-feedback/shimmy/util/cliflags"
 	"github.com/urfave/cli/v2"
+
+	"github.com/lambda-feedback/shimmy/util/cliflags"
 )
 
 type ParseOptions struct {

--- a/util/truthy_test.go
+++ b/util/truthy_test.go
@@ -3,8 +3,9 @@ package util_test
 import (
 	"testing"
 
-	"github.com/lambda-feedback/shimmy/util"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/lambda-feedback/shimmy/util"
 )
 
 func TestTruthy(t *testing.T) {


### PR DESCRIPTION
This PR implements API key authentication using the value provided in the `API_KEY` header with HTTP requests.

The source API key can be provided using the `AUTH.KEY` environment variable, or the `--auth-key` CLI flag.