### PR TITLE
Updated GitHub Actions build workflow to enable `latest` image taggin…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' }}
             type=edge,branch=main
           images: |
             ghcr.io/${{ github.repository }}


### PR DESCRIPTION
…g only for tag refs