### PR TITLE
Add support for configurable application start timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ GLOBAL OPTIONS:
 
    worker
 
-   --worker-send-timeout value  the timeout for a single message send operation. (default: 30s) [$FUNCTION_WORKER_SEND_TIMEOUT]
-   --worker-stop-timeout value  the duration to wait for a worker process to stop. (default: 5s) [$FUNCTION_WORKER_STOP_TIMEOUT]
+   --worker-send-timeout value   the timeout for a single message send operation. (default: 30s) [$FUNCTION_WORKER_SEND_TIMEOUT]
+   --worker-start-timeout value  the duration to wait for the application to start (worker process boot + first successful RPC dial). (default: 15s) [$FUNCTION_WORKER_START_TIMEOUT]
+   --worker-stop-timeout value   the duration to wait for a worker process to stop. (default: 5s) [$FUNCTION_WORKER_STOP_TIMEOUT]
 ```
 
 ## Evaluation Runtime Interface

--- a/app/app.go
+++ b/app/app.go
@@ -32,5 +32,5 @@ func New(ctx *cli.Context) (*shell.Shell, error) {
 		runtime.Module(config.Runtime),
 	)
 
-	return shell.New(log, appModule), nil
+	return shell.New(log, config.StartTimeout, appModule), nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,6 +104,13 @@ functions on arbitrary, serverless platforms.`
 				Category: "worker",
 				EnvVars:  []string{"FUNCTION_WORKER_SEND_TIMEOUT"},
 			},
+			&cli.DurationFlag{
+				Name:     "worker-start-timeout",
+				Usage:    "the duration to wait for the application to start (worker process boot + first successful RPC dial).",
+				Value:    15 * time.Second,
+				Category: "worker",
+				EnvVars:  []string{"FUNCTION_WORKER_START_TIMEOUT"},
+			},
 			&cli.StringFlag{
 				Name:     "rpc-transport",
 				Aliases:  []string{"t"},
@@ -331,6 +338,7 @@ func parseRootConfig(ctx *cli.Context) (config.Config, error) {
 		"rpc-transport-tcp-address":  "runtime.io.rpc.tcp.address",
 		"worker-send-timeout":        "runtime.send.timeout",
 		"worker-stop-timeout":        "runtime.stop.timeout",
+		"worker-start-timeout":       "start_timeout",
 		// sandbox
 		"sandbox":                 "runtime.sandbox.enabled",
 		"sandbox-nsjail-path":     "runtime.sandbox.nsjail_path",

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,10 @@
 package config
 
-import "github.com/lambda-feedback/shimmy/runtime"
+import (
+	"time"
+
+	"github.com/lambda-feedback/shimmy/runtime"
+)
 
 type MessageEncoding string
 
@@ -25,4 +29,7 @@ type Config struct {
 
 	// Auth is the authentication configuration
 	Auth AuthConfig `conf:"auth"`
+
+	// StartTimeout is the duration to wait for the application to start.
+	StartTimeout time.Duration `conf:"start_timeout"`
 }

--- a/internal/execution/supervisor/adapter_rpc.go
+++ b/internal/execution/supervisor/adapter_rpc.go
@@ -191,7 +191,9 @@ func (a *rpcAdapter) dialRpcWithRetry(
 ) error {
 	var err error
 	for i := 0; ; i++ {
-		if client, err := a.dialRpc(ctx, a.config); err == nil {
+		var client *rpc.Client
+		client, err = a.dialRpc(ctx, a.config)
+		if err == nil {
 			a.rpcClient = client
 			return nil
 		}

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxevent"
@@ -9,15 +10,17 @@ import (
 )
 
 type Shell struct {
-	log     *zap.Logger
-	fxApp   *fx.App
-	options []fx.Option
+	log          *zap.Logger
+	fxApp        *fx.App
+	startTimeout time.Duration
+	options      []fx.Option
 }
 
-func New(log *zap.Logger, options ...fx.Option) *Shell {
+func New(log *zap.Logger, startTimeout time.Duration, options ...fx.Option) *Shell {
 	return &Shell{
-		log:     log,
-		options: options,
+		log:          log,
+		startTimeout: startTimeout,
+		options:      options,
 	}
 }
 
@@ -80,10 +83,13 @@ func (s *Shell) createFxApp(ctx context.Context, options ...fx.Option) *fx.App {
 			return &fxevent.ZapLogger{Logger: s.log.Named("fx")}
 		}),
 
-		// 5. provide user-provided options
+		// 5. configure the application start timeout
+		fx.StartTimeout(s.startTimeout),
+
+		// 6. provide user-provided options
 		fx.Options(s.options...),
 
-		// 5. provide user-provided run options
+		// 7. provide user-provided run options
 		fx.Options(options...),
 	)
 }


### PR DESCRIPTION
Integrate `StartTimeout` across configurations and components, enabling a customizable duration for application startup, and update relevant CLI flags and documentation.